### PR TITLE
Fix invalid link

### DIFF
--- a/docs/dev/training.rst
+++ b/docs/dev/training.rst
@@ -9,7 +9,7 @@ SapientML local training
 1. Execution Method
 ===================
 
-Please refer to `this page <https://github.com/sapientml/docs/edit/main/docs/dev/setup.rst>`_ to finish the setup of development environment first.
+Please refer to :doc:`this page <setup>` to finish the setup of development environment first.
 We assume that at this point, **corpus** is downloaded and stored at the **sapientml_core** location, all the pipelines in the corpus is already clean using program slicing and there exists a label file such as *annotated-notebooks/annotated-notebooks-1140.csv* that has all the components for each pipeline. 
 
 * After successfull setup, the following directory structure should reflect.


### PR DESCRIPTION
The link to setup page (labeled as `this page`) in [1. Execution Method](https://sapientml.readthedocs.io/en/latest/dev/training.html) is invalid. Clicking `this page` brings me to the following page. This PR fixes the link.

<img width="1069" alt="image" src="https://github.com/sapientml/docs/assets/1453749/cd559368-a4dc-4c26-b347-62ee754a27fd">
